### PR TITLE
Fix typo in README

### DIFF
--- a/.github/workflows/odfe-cli-test-build-workflow.yml
+++ b/.github/workflows/odfe-cli-test-build-workflow.yml
@@ -1,4 +1,4 @@
-name: ODFE CLI Test
+name: Build and Test odfe-cli
 on:
   push:
     branches:

--- a/odfe-cli/README.md
+++ b/odfe-cli/README.md
@@ -80,7 +80,7 @@ You can specify profiles in two ways.
 
 1. The first way is to add the --profile <name> option:    
     ```
-    $ odfe ad stop-detector invalid-logins --profile prod
+    $ odfe-cli ad stop-detector invalid-logins --profile prod
     ```
     This example stops the invalid-logins detector using the credentials and settings in the prod profile.
     


### PR DESCRIPTION
Update tool name to odfe-cli instead of odfe.
Update workflow name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
